### PR TITLE
Make logout function go to initial menu instead of closing the app

### DIFF
--- a/src/main_menu.py
+++ b/src/main_menu.py
@@ -31,7 +31,6 @@ def learn_skills_menu():
 
 def logout():
     print("Thank you for using InCollege!")
-    exit()
 
 
 optionsAndActions = [
@@ -78,3 +77,6 @@ def main_menu():
             print("Under Construction")
         else:
             action()
+
+        if action == logout:
+            return


### PR DESCRIPTION
Changes the behavior of main_menu to also return to the initial menu when logging out instead of closing the app